### PR TITLE
configuration and spy() injection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,9 @@
 	</parent>
 
 	<description>
-        Needle is a lightweight framework for testing Java EE components outside of the container in isolation. It reduces the test setup code by analysing dependencies and automatic injection of mock objects. It will thus maximize the speed of development as well as the execution of unit tests.
+        Needle is a lightweight framework for testing Java EE components outside of the container in isolation. 
+        It reduces the test setup code by analysing dependencies and automatic injection of mock objects. 
+        It will thus maximize the speed of development as well as the execution of unit tests.
     </description>
 
 	<licenses>
@@ -30,8 +32,8 @@
 		<connection>scm:git:git@github.com:akquinet/needle.git</connection>
 		<url>git@github.com:akquinet/needle.git</url>
 		<developerConnection>scm:git:git@github.com:akquinet/needle.git</developerConnection>
-	  <tag>HEAD</tag>
-  </scm>
+		<tag>HEAD</tag>
+	</scm>
 
 	<developers>
 		<developer>
@@ -54,6 +56,13 @@
 			<email>heinz (dot) wilming (at) akquinet.de</email>
 			<organization>akquinet AG</organization>
 		</developer>
+		
+		<developer>
+			<id>jangalinski</id>
+			<name>Jan Galinski</name>
+			<email>jan (dot) galinski (at) holisticon.de</email>
+			<organization>Holisticon AG</organization>
+		</developer>
 	</developers>
 
 	<organization>
@@ -68,31 +77,25 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<slf4j.version>1.6.4</slf4j.version>
 	</properties>
 
-
 	<dependencies>
+		<!-- logging -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.6.1</version>
+			<version>${slf4j.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>1.6.1</version>
+			<version>${slf4j.version}</version>
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>org.hibernate.javax.persistence</groupId>
-			<artifactId>hibernate-jpa-2.0-api</artifactId>
-			<version>1.0.0.Final</version>
-			<optional>true</optional>
-		</dependency>
-
-
+		<!-- testing -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
@@ -108,19 +111,11 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-entitymanager</artifactId>
-			<version>3.6.0.Final</version>
-			<optional>true</optional>
-		</dependency>
-
-		<dependency>
 			<groupId>org.easymock</groupId>
 			<artifactId>easymock</artifactId>
 			<version>3.1</version>
 			<optional>true</optional>
 		</dependency>
-
 
 		<dependency>
 			<groupId>org.mockito</groupId>
@@ -129,10 +124,18 @@
 			<optional>true</optional>
 		</dependency>
 
+		<!-- jpa/persistence -->
 		<dependency>
-			<groupId>javax.ejb</groupId>
-			<artifactId>ejb-api</artifactId>
-			<version>3.0</version>
+			<groupId>org.hibernate.javax.persistence</groupId>
+			<artifactId>hibernate-jpa-2.0-api</artifactId>
+			<version>1.0.0.Final</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-entitymanager</artifactId>
+			<version>3.6.0.Final</version>
 			<optional>true</optional>
 		</dependency>
 
@@ -142,21 +145,12 @@
 			<version>1.1</version>
 			<optional>true</optional>
 		</dependency>
-
-		<dependency>
-			<groupId>javax.inject</groupId>
-			<artifactId>javax.inject</artifactId>
-			<version>1</version>
-			<optional>true</optional>
-		</dependency>
-
 		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
 			<version>2.2.8</version>
 			<scope>test</scope>
 		</dependency>
-
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
@@ -164,7 +158,20 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- JEE -->
+		<dependency>
+			<groupId>javax.ejb</groupId>
+			<artifactId>ejb-api</artifactId>
+			<version>3.0</version>
+			<optional>true</optional>
+		</dependency>
 
+		<dependency>
+			<groupId>javax.inject</groupId>
+			<artifactId>javax.inject</artifactId>
+			<version>1</version>
+			<optional>true</optional>
+		</dependency>
 
 		<dependency>
 			<groupId>org.jboss.spec.javax.xml.rpc</groupId>

--- a/src/main/java/de/akquinet/jbosscc/needle/NeedleContext.java
+++ b/src/main/java/de/akquinet/jbosscc/needle/NeedleContext.java
@@ -12,50 +12,49 @@ import de.akquinet.jbosscc.needle.reflection.ReflectionUtil;
 
 public class NeedleContext {
 
-	private final Object test;
-	private final Map<String, Object> objectUnderTestMap = new HashMap<String, Object>();
-	private final Map<Object, Object> injectedObjectMap = new HashMap<Object, Object>();
+    private final Object test;
+    private final Map<String, Object> objectUnderTestMap = new HashMap<String, Object>();
+    private final Map<Object, Object> injectedObjectMap = new HashMap<Object, Object>();
 
-	private final Map<Class<? extends Annotation>, List<Field>> annotatedTestcaseFieldMap;
+    private final Map<Class<? extends Annotation>, List<Field>> annotatedTestcaseFieldMap;
 
-	public NeedleContext(final Object test) {
-		super();
-		this.test = test;
-		annotatedTestcaseFieldMap = ReflectionUtil.getAllAnnotatedFields(test.getClass());
-	}
+    public NeedleContext(final Object test) {
+        this.test = test;
+        annotatedTestcaseFieldMap = ReflectionUtil.getAllAnnotatedFields(test.getClass());
+    }
 
-	public Object getTest() {
-		return test;
-	}
+    public Object getTest() {
+        return test;
+    }
 
-	@SuppressWarnings("unchecked")
-	public <X> X getInjectedObject(final Object key) {
-		return (X) injectedObjectMap.get(key);
-	}
+    @SuppressWarnings("unchecked")
+    public <X> X getInjectedObject(final Object key) {
+        return (X)injectedObjectMap.get(key);
+    }
 
-	public Collection<Object> getInjectedObjects() {
-		return injectedObjectMap.values();
-	}
+    public Collection<Object> getInjectedObjects() {
+        return injectedObjectMap.values();
+    }
 
-	public void addInjectedObject(final Object key, final Object instance) {
-		injectedObjectMap.put(key, instance);
-	}
+    public void addInjectedObject(final Object key, final Object instance) {
+        injectedObjectMap.put(key, instance);
+    }
 
-	public Object getObjectUnderTest(String id) {
-		return objectUnderTestMap.get(id);
-	}
+    public Object getObjectUnderTest(final String id) {
+        return objectUnderTestMap.get(id);
+    }
 
-	public void addObjectUnderTest(final String id, final Object instance) {
-		objectUnderTestMap.put(id, instance);
-	}
+    public void addObjectUnderTest(final String id, final Object instance) {
+        objectUnderTestMap.put(id, instance);
+    }
 
-	public Collection<Object> getObjectsUnderTest() {
-		return objectUnderTestMap.values();
-	}
+    public Collection<Object> getObjectsUnderTest() {
+        return objectUnderTestMap.values();
+    }
 
-	public List<Field> getAnnotatedTestcaseFields(final Class<? extends Annotation> annotationClass){
-		final List<Field> value = annotatedTestcaseFieldMap.get(annotationClass);
-		return value != null ? value : new ArrayList<Field>();
-	}
+    public List<Field> getAnnotatedTestcaseFields(final Class<? extends Annotation> annotationClass) {
+        final List<Field> value = annotatedTestcaseFieldMap.get(annotationClass);
+        return value != null ? value : new ArrayList<Field>();
+    }
 
 }

--- a/src/main/java/de/akquinet/jbosscc/needle/common/MapEntry.java
+++ b/src/main/java/de/akquinet/jbosscc/needle/common/MapEntry.java
@@ -2,28 +2,27 @@ package de.akquinet.jbosscc.needle.common;
 
 public class MapEntry<K, V> implements java.util.Map.Entry<K, V> {
 
-	private K key;
-	private V value;
+    private K key;
+    private V value;
 
-	public MapEntry(K key, V value) {
-	    super();
-	    this.key = key;
-	    this.value = value;
+    public MapEntry(final K key, final V value) {
+        this.key = key;
+        this.value = value;
     }
 
-	@Override
-	public K getKey() {
-		return key;
-	}
+    @Override
+    public K getKey() {
+        return key;
+    }
 
-	@Override
-	public V getValue() {
-		return value;
-	}
+    @Override
+    public V getValue() {
+        return value;
+    }
 
-	@Override
-	public V setValue(Object value) {
-		throw new UnsupportedOperationException();
-	}
+    @Override
+    public V setValue(final Object value) {
+        throw new UnsupportedOperationException();
+    }
 
 }

--- a/src/main/java/de/akquinet/jbosscc/needle/common/Preconditions.java
+++ b/src/main/java/de/akquinet/jbosscc/needle/common/Preconditions.java
@@ -1,0 +1,22 @@
+package de.akquinet.jbosscc.needle.common;
+
+import static java.lang.String.format;
+
+/**
+ * Utility class for checks and verifications. Inspired by guava/Preconditions, but without adding the external
+ * dependency.
+ * 
+ * @author Jan Galinski, Holisticon AG
+ */
+public final class Preconditions {
+
+    private Preconditions() {
+        // avoid instantiation.
+    }
+
+    public static void checkState(final boolean expression, final String message, final Object... parameters) {
+        if (!expression) {
+            throw new IllegalStateException(format(message, parameters));
+        }
+    }
+}

--- a/src/main/java/de/akquinet/jbosscc/needle/configuration/ConfigurationLoader.java
+++ b/src/main/java/de/akquinet/jbosscc/needle/configuration/ConfigurationLoader.java
@@ -13,66 +13,87 @@ import org.slf4j.LoggerFactory;
 
 public final class ConfigurationLoader {
 
-	private static final Logger LOG = LoggerFactory.getLogger(ConfigurationLoader.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ConfigurationLoader.class);
 
-	private final Map<String, String> configProperties;
+    private final Map<String, String> configProperties;
 
-	private static final String DEFAULT_CONFIGURATION_FILENAME = "needle-defaults";
+    static final String CUSTOM_CONFIGURATION_FILENAME = "needle";
+    private static final String DEFAULT_CONFIGURATION_FILENAME = "needle-defaults";
 
-	ConfigurationLoader() {
-		super();
-		configProperties = loadResourceAndDefault("needle");
-	}
+    /**
+     * @see #ConfigurationLoader(String)
+     */
+    ConfigurationLoader() {
+        this(CUSTOM_CONFIGURATION_FILENAME);
+    }
 
-	String getProperty(final String key) {
-		return configProperties.get(key);
-	}
+    ConfigurationLoader(final String resourceName) {
+        configProperties = loadResourceAndDefault(resourceName);
+    }
 
-	boolean containsKey(String key) {
-		return configProperties.containsKey(key);
-	}
+    /**
+     * @deprecated values are accessed in NeedleConfiguration
+     * @param key
+     * @return
+     */
+    @Deprecated
+    String getProperty(final String key) {
+        return configProperties.get(key);
+    }
 
-	Map<String, String> loadResourceAndDefault(String name) {
-		final Map<String, String> result = new HashMap<String, String>();
+    /**
+     * @deprecated values are accessed in NeedleConfiguration
+     * @param key
+     * @return
+     */
+    @Deprecated
+    boolean containsKey(final String key) {
+        return configProperties.containsKey(key);
+    }
 
-		try {
-			ResourceBundle customBundle = loadResourceBundle(name);
+    static Map<String, String> loadResourceAndDefault(final String name) {
+        final Map<String, String> result = new HashMap<String, String>();
 
-			for (Enumeration<String> keys = customBundle.getKeys(); keys.hasMoreElements();) {
-				String key = keys.nextElement();
+        try {
+            final ResourceBundle customBundle = ResourceBundle.getBundle(name);
+
+            for (final Enumeration<String> keys = customBundle.getKeys(); keys.hasMoreElements();) {
+                final String key = keys.nextElement();
                 addKeyValuePair(result, key, customBundle.getString(key));
-			}
+            }
 
-			URL url = NeedleConfiguration.class.getResource("/" + name + ".properties");
-			LOG.info("loaded Needle config named {} from {}", name, url);
-		} catch (Exception e) {
-			LOG.debug("found no custom configuration");
-		}
+            final URL url = NeedleConfiguration.class.getResource("/" + name + ".properties");
+            LOG.info("loaded Needle config named {} from {}", name, url);
+        }
+        catch (final Exception e) {
+            LOG.debug("found no custom configuration");
+        }
 
-		try {
+        try {
 
-			ResourceBundle defaultResourceBundle = loadResourceBundle(DEFAULT_CONFIGURATION_FILENAME);
+            final ResourceBundle defaultResourceBundle = ResourceBundle.getBundle(DEFAULT_CONFIGURATION_FILENAME);
 
-			for (Enumeration<String> keys = defaultResourceBundle.getKeys(); keys.hasMoreElements();) {
-				String key = keys.nextElement();
-				if (!result.containsKey(key)) {
+            for (final Enumeration<String> keys = defaultResourceBundle.getKeys(); keys.hasMoreElements();) {
+                final String key = keys.nextElement();
+                if (!result.containsKey(key)) {
                     addKeyValuePair(result, key, defaultResourceBundle.getString(key));
-				}
-			}
+                }
+            }
 
-			URL url = NeedleConfiguration.class.getResource("/" + DEFAULT_CONFIGURATION_FILENAME + ".properties");
-			LOG.debug("loaded default Needle config from: {}", url);
-		} catch (Exception e1) {
-			LOG.error("should never happen", e1);
+            final URL url = NeedleConfiguration.class.getResource("/" + DEFAULT_CONFIGURATION_FILENAME + ".properties");
+            LOG.debug("loaded default Needle config from: {}", url);
+        }
+        catch (final Exception e1) {
+            LOG.error("should never happen", e1);
 
-			throw new RuntimeException("should never happen", e1);
-		}
+            throw new RuntimeException("should never happen", e1);
+        }
 
-		return result;
-	}
+        return result;
+    }
 
-    private void addKeyValuePair(Map<String, String> target, String key, String value) {
-        String trimmedValue = value.trim();
+    private static void addKeyValuePair(final Map<String, String> target, final String key, final String value) {
+        final String trimmedValue = value.trim();
 
         if (!trimmedValue.equals(value)) {
             LOG.warn("trimmed value " + value + " to " + trimmedValue + " (key was " + key + ")");
@@ -81,37 +102,37 @@ public final class ConfigurationLoader {
         target.put(key, trimmedValue);
     }
 
-	private ResourceBundle loadResourceBundle(String name) {
-		return ResourceBundle.getBundle(name);
-	}
+    public Map<String, String> getConfigProperties() {
+        return configProperties;
+    }
 
-	/**
-	 * Returns an input stream for reading the specified resource.
-	 *
-	 * @param resource
-	 *            the resource name
-	 * @return an input stream for reading the resource.
-	 * @throws FileNotFoundException
-	 *             if the resource could not be found
-	 */
-	public static InputStream loadResource(final String resource) throws FileNotFoundException {
-		boolean hasLeadingSlash = resource.startsWith("/");
-		String stripped = hasLeadingSlash ? resource.substring(1) : resource;
+    /**
+     * Returns an input stream for reading the specified resource.
+     * 
+     * @param resource
+     *        the resource name
+     * @return an input stream for reading the resource.
+     * @throws FileNotFoundException
+     *         if the resource could not be found
+     */
+    public static InputStream loadResource(final String resource) throws FileNotFoundException {
+        final boolean hasLeadingSlash = resource.startsWith("/");
+        final String stripped = hasLeadingSlash ? resource.substring(1) : resource;
 
-		InputStream stream = null;
+        InputStream stream = null;
 
-		ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-		if (classLoader != null) {
-			stream = classLoader.getResourceAsStream(resource);
-			if (stream == null && hasLeadingSlash) {
-				stream = classLoader.getResourceAsStream(stripped);
-			}
-		}
+        final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader != null) {
+            stream = classLoader.getResourceAsStream(resource);
+            if (stream == null && hasLeadingSlash) {
+                stream = classLoader.getResourceAsStream(stripped);
+            }
+        }
 
-		if (stream == null) {
-			throw new FileNotFoundException("resource " + resource + " not found");
-		}
+        if (stream == null) {
+            throw new FileNotFoundException("resource " + resource + " not found");
+        }
 
-		return stream;
-	}
+        return stream;
+    }
 }

--- a/src/main/java/de/akquinet/jbosscc/needle/configuration/NeedleConfiguration.java
+++ b/src/main/java/de/akquinet/jbosscc/needle/configuration/NeedleConfiguration.java
@@ -60,8 +60,12 @@ public final class NeedleConfiguration {
     private final Set<Class<InjectionProvider<?>>> customInjectionProviderClasses;
     private final Set<Class<Annotation>> customInjectionAnnotations;
 
+    /**
+     * @see #NeedleConfiguration(Map)
+     * @param resourceName - properties file to load, default is "needle.properties"
+     */
     private NeedleConfiguration(final String resourceName) {
-        this(new ConfigurationLoader(resourceName).getConfigProperties());
+        this(ConfigurationLoader.loadResourceAndDefault(resourceName));
     }
 
     private NeedleConfiguration(final Map<String, String> configurationProperties) {
@@ -69,7 +73,6 @@ public final class NeedleConfiguration {
         this.customInjectionAnnotations = lookupClasses(CUSTOM_INJECTION_ANNOTATIONS_KEY);
         this.customInjectionProviderClasses = lookupClasses(CUSTOM_INJECTION_PROVIDER_CLASSES_KEY);
         LOG.info("Needle Configuration: {}", toString());
-
     }
 
     /**

--- a/src/main/java/de/akquinet/jbosscc/needle/db/configuration/EJB3Configuration.java
+++ b/src/main/java/de/akquinet/jbosscc/needle/db/configuration/EJB3Configuration.java
@@ -13,48 +13,49 @@ import de.akquinet.jbosscc.needle.configuration.NeedleConfiguration;
 @Deprecated
 class EJB3Configuration implements PersistenceConfiguration {
 
-	private final EntityManagerFactory factory;
-	private final EntityManager entityManager;
+    private final EntityManagerFactory factory;
+    private final EntityManager entityManager;
 
-	/**
-	 * Creates an {@link EntityManagerFactory} and {@link EntityManager} for the
-	 * given entity classes by using the configured hibernate specific
-	 * configuration file (*cfg.xml).
-	 *
-	 * @param entityClasses
-	 *            the entity classes
-	 */
-	public EJB3Configuration(final Class<?>[] entityClasses) {
-		factory = createEntityManagerFactory(entityClasses);
-		entityManager = EntityManagerProxyFactory.createProxy(factory.createEntityManager());
-	}
+    /**
+     * Creates an {@link EntityManagerFactory} and {@link EntityManager} for the
+     * given entity classes by using the configured hibernate specific
+     * configuration file (*cfg.xml).
+     * 
+     * @param entityClasses
+     *        the entity classes
+     */
+    public EJB3Configuration(final Class<?>[] entityClasses) {
+        factory = createEntityManagerFactory(entityClasses);
+        entityManager = EntityManagerProxyFactory.createProxy(factory.createEntityManager());
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public EntityManager getEntityManager() {
-		return entityManager;
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public EntityManager getEntityManager() {
+        return entityManager;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public EntityManagerFactory getEntityManagerFactory() {
-		return factory;
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public EntityManagerFactory getEntityManagerFactory() {
+        return factory;
+    }
 
-	private static EntityManagerFactory createEntityManagerFactory(Class<?>[] entityClasses) {
-		final Ejb3Configuration cfg = new Ejb3Configuration();
+    private static EntityManagerFactory createEntityManagerFactory(final Class<?>[] entityClasses) {
+        final Ejb3Configuration cfg = new Ejb3Configuration();
 
-		// add a regular hibernate.cfg.xml
-		cfg.configure(NeedleConfiguration.getHibernateCfgFilename());
+        // add a regular hibernate.cfg.xml
+        cfg.configure(NeedleConfiguration.get().getHibernateCfgFilename());
 
-		for (Class<?> clazz : entityClasses) {
-			cfg.addAnnotatedClass(clazz);
-		}
+        for (final Class<?> clazz : entityClasses) {
+            cfg.addAnnotatedClass(clazz);
+        }
 
-		return cfg.buildEntityManagerFactory();
+        return cfg.buildEntityManagerFactory();
 
-	}
+    }
 }

--- a/src/main/java/de/akquinet/jbosscc/needle/mock/MockitoProvider.java
+++ b/src/main/java/de/akquinet/jbosscc/needle/mock/MockitoProvider.java
@@ -1,32 +1,63 @@
 package de.akquinet.jbosscc.needle.mock;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
 
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * A Mockito specific {@link MockProvider} implementation. For more details, see
  * the Mockito documentation.
- *
  */
-public class MockitoProvider implements MockProvider {
-	private static final Logger LOG = LoggerFactory.getLogger(MockitoProvider.class);
+public class MockitoProvider implements MockProvider, SpyProvider {
 
-	/**
-	 * {@inheritDoc} Skipping creation, if the type is final or primitive.
-	 *
-	 * @return the mock object or null, if the type is final or primitive.
-	 */
-	@Override
-	public <T> T createMockComponent(Class<T> type) {
-		if (Modifier.isFinal(type.getModifiers()) || type.isPrimitive()) {
-			LOG.warn("Skipping creation of a mock : {} as it is final or primitive type.", type.getSimpleName());
-			return null;
-		}
+    private static final Logger LOG = LoggerFactory.getLogger(MockitoProvider.class);
 
-		return Mockito.mock(type);
-	}
+    /**
+     * {@inheritDoc} Skipping creation, if the type is final or primitive.
+     * 
+     * @return the mock object or null, if the type is final or primitive.
+     */
+    @Override
+    public <T> T createMockComponent(final Class<T> type) {
+        if (isFinalOrPrimitive(type)) {
+            LOG.warn("Skipping creation of a mock : {} as it is final or primitive type.", type.getSimpleName());
+            return null;
+        }
 
+        return Mockito.mock(type);
+    }
+
+    /**
+     * {@inheritDoc} Skipping creation, if the type is final or primitive.
+     * 
+     * @return the mock object or null, if the type is final or primitive.
+     */
+    @Override
+    public <T> T createSpyComponent(final T instance) {
+        if (instance == null) {
+            throw new IllegalArgumentException("instance must not be null!");
+        }
+        if (isFinalOrPrimitive(instance.getClass())) {
+            LOG.warn("Skipping creation of a spy : {} as it is final or primitive type.", instance.getClass().getSimpleName());
+            return null;
+        }
+        return Mockito.spy(instance);
+    }
+
+    /**
+     * @param type
+     * @return <code>true</code> if type is final or primitive, <code>false</code> else.
+     */
+    private boolean isFinalOrPrimitive(final Class<?> type) {
+        return Modifier.isFinal(type.getModifiers()) || type.isPrimitive();
+    }
+
+    @Override
+    public Class<? extends Annotation> getSpyAnnotation() {
+        return Spy.class;
+    }
 }

--- a/src/main/java/de/akquinet/jbosscc/needle/mock/SpyAnnotationProcessor.java
+++ b/src/main/java/de/akquinet/jbosscc/needle/mock/SpyAnnotationProcessor.java
@@ -1,0 +1,56 @@
+package de.akquinet.jbosscc.needle.mock;
+
+import java.lang.reflect.Field;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The SpyAnnotationProcessor modifies the given instance so it becomes a spy (hybrid of mock and real pojo).
+ * It checks if the configured {@link MockProvider} supports spies, and if the current objectUnderTest instance is
+ * marked with a spy annotation.
+ * 
+ * @author Jan Galinski, Holisticon AG
+ */
+public class SpyAnnotationProcessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SpyAnnotationProcessor.class);
+
+    private final SpyProvider spyProvider;
+
+    public SpyAnnotationProcessor(final MockProvider mockProvider) {
+        this.spyProvider = (mockProvider instanceof SpyProvider)
+                ? (SpyProvider)mockProvider
+                : null;
+    }
+
+    /**
+     * @param objectUnderTest - the instance that should become a spy
+     * @param field - the field, needed for annotation access
+     * @return modified spy-instance
+     */
+    public <T> T process(final T objectUnderTest, final Field field) {
+        // mockProvider does not allow spies: return instance without modification
+        if (!isSpySupported()) {
+            LOG.debug("The mockprovider does not support spying. Skipping creation for " + field);
+            return objectUnderTest;
+        }
+
+        // create Spy if Annotation is present, just return instance else.
+        return (isSpyRequested(field))
+                ? spyProvider.createSpyComponent(objectUnderTest)
+                : objectUnderTest;
+    }
+
+    private boolean isSpySupported() {
+        return spyProvider != null;
+    }
+
+    /**
+     * @param field
+     * @return <code>true</code> if spy-provider is set and current field is annotated as spy, <code>false</code> else.
+     */
+    public boolean isSpyRequested(final Field field) {
+        return isSpySupported() && field.isAnnotationPresent(spyProvider.getSpyAnnotation());
+    }
+}

--- a/src/main/java/de/akquinet/jbosscc/needle/mock/SpyProvider.java
+++ b/src/main/java/de/akquinet/jbosscc/needle/mock/SpyProvider.java
@@ -1,0 +1,22 @@
+package de.akquinet.jbosscc.needle.mock;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * Interface to abstract the creation of spy() instances, if the used framework allows to do so.
+ * 
+ * @author Jan Galinski, Holisticon AG
+ */
+public interface SpyProvider {
+
+    /**
+     * @param instance
+     * @return Spy of instance (spy(instance) for Mockito)
+     */
+    <T> T createSpyComponent(T instance);
+
+    /**
+     * @return the Annotation used to trigger the spy creation. (@Spy for Mockito)
+     */
+    Class<? extends Annotation> getSpyAnnotation();
+}

--- a/src/main/java/de/akquinet/jbosscc/needle/reflection/ReflectionUtil.java
+++ b/src/main/java/de/akquinet/jbosscc/needle/reflection/ReflectionUtil.java
@@ -60,6 +60,27 @@ public final class ReflectionUtil {
         return result;
     }
 
+    public static List<Method> getAllMethodsWithAnnotation(final Class<?> clazz,
+            final Class<? extends Annotation> annotation) {
+        final List<Method> result = new ArrayList<Method>();
+
+        new DerivedClassIterator(clazz) {
+
+            @Override
+            protected void handleClass(final Class<?> clazz) {
+
+                for (final Method method : clazz.getDeclaredMethods()) {
+                    if (method.isAnnotationPresent(annotation)) {
+                        result.add(method);
+                    }
+                }
+
+            }
+        }.iterate();
+
+        return result;
+    }
+
     public static Map<Class<? extends Annotation>, List<Field>> getAllAnnotatedFields(final Class<?> clazz) {
         final Map<Class<? extends Annotation>, List<Field>> result = new HashMap<Class<? extends Annotation>, List<Field>>();
         final List<Field> fields = getAllFields(clazz);
@@ -130,10 +151,8 @@ public final class ReflectionUtil {
     }
 
     /**
-     * 
      * @param class object
      * @return list of method objects
-     * 
      * @see Class#getMethods()
      */
     public static List<Method> getMethods(final Class<?> clazz) {
@@ -144,13 +163,13 @@ public final class ReflectionUtil {
      * Changing the value of a given field.
      * 
      * @param object
-     *            -- target object of injection
+     *        -- target object of injection
      * @param clazz
-     *            -- type of argument object
+     *        -- type of argument object
      * @param fieldName
-     *            -- name of field whose value is to be set
+     *        -- name of field whose value is to be set
      * @param value
-     *            -- object that is injected
+     *        -- object that is injected
      */
     public static void setFieldValue(final Object object, final Class<?> clazz, final String fieldName,
             final Object value) throws NoSuchFieldException {
@@ -158,7 +177,8 @@ public final class ReflectionUtil {
 
         try {
             setField(field, object, value);
-        } catch (final Exception e) {
+        }
+        catch (final Exception e) {
             LOG.error(e.getMessage(), e);
         }
     }
@@ -167,11 +187,11 @@ public final class ReflectionUtil {
      * Changing the value of a given field.
      * 
      * @param object
-     *            -- target object of injection
+     *        -- target object of injection
      * @param fieldName
-     *            -- name of field whose value is to be set
+     *        -- name of field whose value is to be set
      * @param value
-     *            -- object that is injected
+     *        -- object that is injected
      */
     public static void setFieldValue(final Object object, final String fieldName, final Object value) {
 
@@ -182,7 +202,8 @@ public final class ReflectionUtil {
                 try {
                     setFieldValue(object, clazz, fieldName, value);
                     return;
-                } catch (final NoSuchFieldException e) {
+                }
+                catch (final NoSuchFieldException e) {
                     LOG.warn("could not set field " + fieldName + " value " + value, e);
                 }
 
@@ -195,11 +216,11 @@ public final class ReflectionUtil {
      * Get the value of a given field on a given object via reflection.
      * 
      * @param object
-     *            -- target object of field access
+     *        -- target object of field access
      * @param clazz
-     *            -- type of argument object
+     *        -- type of argument object
      * @param fieldName
-     *            -- name of the field
+     *        -- name of the field
      * @return -- the value of the represented field in object; primitive values
      *         are wrapped in an appropriate object before being returned
      */
@@ -207,7 +228,8 @@ public final class ReflectionUtil {
         try {
             final Field field = clazz.getDeclaredField(fieldName);
             return getFieldValue(object, field);
-        } catch (final Exception e) {
+        }
+        catch (final Exception e) {
             throw new IllegalArgumentException("Could not get field value: " + fieldName, e);
         }
     }
@@ -216,10 +238,9 @@ public final class ReflectionUtil {
      * Get the value of a given field on a given object via reflection.
      * 
      * @param object
-     *            -- target object of field access
+     *        -- target object of field access
      * @param field
-     *            -- target field
-     * 
+     *        -- target field
      * @return -- the value of the represented field in object; primitive values
      *         are wrapped in an appropriate object before being returned
      */
@@ -230,7 +251,8 @@ public final class ReflectionUtil {
             }
 
             return field.get(object);
-        } catch (final Exception e) {
+        }
+        catch (final Exception e) {
             throw new IllegalArgumentException("Could not get field value: " + field, e);
         }
     }
@@ -239,9 +261,9 @@ public final class ReflectionUtil {
      * Get the value of a given field on a given object via reflection.
      * 
      * @param object
-     *            -- target object of field access
+     *        -- target object of field access
      * @param fieldName
-     *            -- name of the field
+     *        -- name of the field
      * @return -- the value of the represented field in object; primitive values
      *         are wrapped in an appropriate object before being returned
      */
@@ -254,16 +276,16 @@ public final class ReflectionUtil {
      * reflection.
      * 
      * @param object
-     *            -- target object of invocation
+     *        -- target object of invocation
      * @param clazz
-     *            -- type of argument object
+     *        -- type of argument object
      * @param methodName
-     *            -- name of method to be invoked
+     *        -- name of method to be invoked
      * @param arguments
-     *            -- arguments for method invocation
+     *        -- arguments for method invocation
      * @return -- method object to which invocation is actually dispatched
      * @throws Exception
-     *             - operation exception
+     *         - operation exception
      */
     public static Object invokeMethod(final Object object, final Class<?> clazz, final String methodName,
             final Object... arguments) throws Exception {
@@ -295,11 +317,12 @@ public final class ReflectionUtil {
             }
 
             return method.invoke(instance, arguments);
-        } catch (final Exception exc) {
+        }
+        catch (final Exception exc) {
             LOG.warn("Error invoking method: " + method.getName(), exc);
             final Throwable cause = exc.getCause();
             if (cause instanceof Exception) {
-                throw (Exception) cause;
+                throw (Exception)cause;
             }
             throw exc;
         }
@@ -317,7 +340,8 @@ public final class ReflectionUtil {
                 try {
                     result.add(clazz.getDeclaredMethod(methodName, parameterTypes));
                     return;
-                } catch (final Exception e) {
+                }
+                catch (final Exception e) {
                     // do nothing
                 }
 
@@ -361,11 +385,11 @@ public final class ReflectionUtil {
      * reflection.
      * 
      * @param object
-     *            -- target object of invocation
+     *        -- target object of invocation
      * @param methodName
-     *            -- name of method to be invoked
+     *        -- name of method to be invoked
      * @param arguments
-     *            -- arguments for method invocation
+     *        -- arguments for method invocation
      * @return -- method object to which invocation is actually dispatched
      * @throws Exception
      */
@@ -375,8 +399,8 @@ public final class ReflectionUtil {
     }
 
     public static Set<Class<?>> getClasses(final String... classNames) {
-        Set<Class<?>> classes = new HashSet<Class<?>>();
-        for (String className : classNames) {
+        final Set<Class<?>> classes = new HashSet<Class<?>>();
+        for (final String className : classNames) {
             final Class<?> classObject = forName(className);
 
             if (classObject != null) {
@@ -391,13 +415,14 @@ public final class ReflectionUtil {
      * interface with the given string name.
      * 
      * @param className
-     *            the fully qualified name of the desired class.
+     *        the fully qualified name of the desired class.
      * @return <code>Class</code> or null
      */
     public static Class<?> forName(final String className) {
         try {
             return Class.forName(className);
-        } catch (final ClassNotFoundException e) {
+        }
+        catch (final ClassNotFoundException e) {
             return null;
         }
     }
@@ -440,7 +465,8 @@ public final class ReflectionUtil {
     private static Field getFieldByName(final Class<?> clazz, final String fieldName) {
         try {
             return clazz.getDeclaredField(fieldName);
-        } catch (final NoSuchFieldException e) {
+        }
+        catch (final NoSuchFieldException e) {
             LOG.warn(e.getMessage(), e);
             return null;
         }

--- a/src/test/java/de/akquinet/jbosscc/needle/MyComponentBean.java
+++ b/src/test/java/de/akquinet/jbosscc/needle/MyComponentBean.java
@@ -10,56 +10,55 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceContext;
 
+@SuppressWarnings("rawtypes")
 public class MyComponentBean implements MyComponent {
 
-	@PersistenceContext
-	private EntityManager entityManager;
+    @PersistenceContext
+    private EntityManager entityManager;
 
-	@Inject
-	private EntityManagerFactory entityManagerFactory;
+    @Inject
+    private EntityManagerFactory entityManagerFactory;
 
-	@EJB
-	private MyEjbComponent myEjbComponent;
+    @EJB
+    private MyEjbComponent myEjbComponent;
 
-	@Resource
-	private SessionContext sessionContext;
+    @Resource
+    private SessionContext sessionContext;
 
-	@Resource(mappedName = "queue1")
-	private Queue queue1;
+    @Resource(mappedName = "queue1")
+    private Queue queue1;
 
-	@Resource(mappedName = "queue2")
-	private Queue queue2;
+    @Resource(mappedName = "queue2")
+    private Queue queue2;
 
-	public EntityManager getEntityManager() {
-		return entityManager;
-	}
-
-	public MyEjbComponent getMyEjbComponent() {
-		return myEjbComponent;
-	}
-
-	@Override
-	public String testMock() {
-		queue2.clear();
-		return myEjbComponent.doSomething();
-	}
-
-	public EntityManagerFactory getEntityManagerFactory() {
-		return entityManagerFactory;
-	}
-
-	public SessionContext getSessionContext() {
-    	return sessionContext;
+    public EntityManager getEntityManager() {
+        return entityManager;
     }
 
-	public Queue getQueue1() {
-    	return queue1;
+    public MyEjbComponent getMyEjbComponent() {
+        return myEjbComponent;
     }
 
-	public Queue getQueue2() {
-    	return queue2;
+    @Override
+    public String testMock() {
+        queue2.clear();
+        return myEjbComponent.doSomething();
     }
-	
-	
+
+    public EntityManagerFactory getEntityManagerFactory() {
+        return entityManagerFactory;
+    }
+
+    public SessionContext getSessionContext() {
+        return sessionContext;
+    }
+
+    public Queue getQueue1() {
+        return queue1;
+    }
+
+    public Queue getQueue2() {
+        return queue2;
+    }
 
 }

--- a/src/test/java/de/akquinet/jbosscc/needle/ObjectUnderTestInstantiationTest.java
+++ b/src/test/java/de/akquinet/jbosscc/needle/ObjectUnderTestInstantiationTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import de.akquinet.jbosscc.needle.annotation.ObjectUnderTest;
 import de.akquinet.jbosscc.needle.reflection.ReflectionUtil;
 
+@SuppressWarnings("unused")
 public class ObjectUnderTestInstantiationTest {
 
     @ObjectUnderTest
@@ -35,11 +36,10 @@ public class ObjectUnderTestInstantiationTest {
     }
 
     private void setInstanceIfNotNull(final String fieldName) throws Exception {
-        NeedleTestcase needleTestcase = new NeedleTestcase() {
-        };
+        final NeedleTestcase needleTestcase = new NeedleTestcase() {};
 
-        Field field = ObjectUnderTestInstantiationTest.class.getDeclaredField(fieldName);
-        ObjectUnderTest objectUnderTestAnnotation = field.getAnnotation(ObjectUnderTest.class);
+        final Field field = ObjectUnderTestInstantiationTest.class.getDeclaredField(fieldName);
+        final ObjectUnderTest objectUnderTestAnnotation = field.getAnnotation(ObjectUnderTest.class);
 
         ReflectionUtil.invokeMethod(needleTestcase, "setInstanceIfNotNull", field, objectUnderTestAnnotation, this);
 

--- a/src/test/java/de/akquinet/jbosscc/needle/common/PreconditionsTest.java
+++ b/src/test/java/de/akquinet/jbosscc/needle/common/PreconditionsTest.java
@@ -1,0 +1,28 @@
+package de.akquinet.jbosscc.needle.common;
+
+import static de.akquinet.jbosscc.needle.common.Preconditions.checkState;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class PreconditionsTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void shouldThrowIllegalStateException() {
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("failed with param=foo");
+
+        checkState(false, "failed with param=%s", "foo");
+    }
+
+    @Test
+    public void shouldPassWithoutException() {
+        checkState(true, "should pass");
+        // success if no exception thrown
+    }
+
+}

--- a/src/test/java/de/akquinet/jbosscc/needle/configuration/ConfigurationLoaderTest.java
+++ b/src/test/java/de/akquinet/jbosscc/needle/configuration/ConfigurationLoaderTest.java
@@ -1,57 +1,63 @@
 package de.akquinet.jbosscc.needle.configuration;
 
+import static de.akquinet.jbosscc.needle.configuration.NeedleConfiguration.HIBERNATE_CFG_FILENAME_KEY;
+import static de.akquinet.jbosscc.needle.configuration.NeedleConfiguration.JDBC_URL_KEY;
+import static de.akquinet.jbosscc.needle.configuration.NeedleConfiguration.PERSISTENCEUNIT_NAME_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.Map;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ConfigurationLoaderTest {
 
-	private ConfigurationLoader configurationLoader = new ConfigurationLoader();
+    private final ConfigurationLoader configurationLoader = new ConfigurationLoader();
 
-	@Test
-	public void testContainsKey() throws Exception {
-		Assert.assertFalse(configurationLoader.containsKey("anykey"));
-		Assert.assertTrue(configurationLoader.containsKey(NeedleConfiguration.PERSISTENCEUNIT_NAME_KEY));
-	}
+    @Test
+    public void testContainsKey() throws Exception {
+        assertFalse(configurationLoader.containsKey("anykey"));
+        assertTrue(configurationLoader.containsKey(PERSISTENCEUNIT_NAME_KEY));
+    }
 
-	@Test
-	public void testGetProperty() throws Exception {
-		Assert.assertEquals("TestDataModel", configurationLoader.getProperty(NeedleConfiguration.PERSISTENCEUNIT_NAME_KEY));
-		Assert.assertNull(configurationLoader.getProperty("any key"));
-	}
+    @Test
+    public void testGetProperty() throws Exception {
+        assertEquals("TestDataModel", configurationLoader.getProperty(PERSISTENCEUNIT_NAME_KEY));
+        assertNull(configurationLoader.getProperty("any key"));
+    }
 
-	@Test
-	public void canLoadCustomBundle() throws Exception {
-		Map<String, String> loadResourceAndDefault = configurationLoader.loadResourceAndDefault("needle-custom");
-		Assert.assertNotNull(loadResourceAndDefault);
-		Assert.assertEquals("jdbc-custom", loadResourceAndDefault.get(NeedleConfiguration.JDBC_URL_KEY));
-		Assert.assertEquals("needle-hsql-hibernate.cfg.xml",
-		        loadResourceAndDefault.get(NeedleConfiguration.HIBERNATE_CFG_FILENAME_KEY));
-	}
+    @Test
+    public void canLoadCustomBundle() throws Exception {
+        final Map<String, String> loadResourceAndDefault = ConfigurationLoader.loadResourceAndDefault("needle-custom");
+        assertNotNull(loadResourceAndDefault);
+        assertEquals("jdbc-custom", loadResourceAndDefault.get(JDBC_URL_KEY));
+        assertEquals("needle-hsql-hibernate.cfg.xml", loadResourceAndDefault.get(HIBERNATE_CFG_FILENAME_KEY));
+    }
 
-	@Test
-	public void defaultResourceBundleIsFetched() throws Exception {
-		Map<String, String> loadResourceAndDefault = configurationLoader.loadResourceAndDefault("not-existing");
-		Assert.assertNotNull(loadResourceAndDefault);
-		Assert.assertEquals("needle-hsql-hibernate.cfg.xml",
-		        loadResourceAndDefault.get(NeedleConfiguration.HIBERNATE_CFG_FILENAME_KEY));
-	}
+    @Test
+    public void defaultResourceBundleIsFetched() throws Exception {
+        final Map<String, String> loadResourceAndDefault = ConfigurationLoader.loadResourceAndDefault("not-existing");
+        assertNotNull(loadResourceAndDefault);
+        assertEquals("needle-hsql-hibernate.cfg.xml", loadResourceAndDefault.get(HIBERNATE_CFG_FILENAME_KEY));
+    }
 
-	@Test
-	public void testLoadResource() throws Exception {
-		InputStream loadResource = ConfigurationLoader.loadResource("needle.properties");
-		Assert.assertNotNull(loadResource);
+    @Test
+    public void testLoadResource() throws Exception {
+        final InputStream loadResource = ConfigurationLoader.loadResource("needle.properties");
+        assertNotNull(loadResource);
 
-		InputStream loadResourceWithLeadingSlash = ConfigurationLoader.loadResource("/needle.properties");
-		Assert.assertNotNull(loadResourceWithLeadingSlash);
-	}
+        final InputStream loadResourceWithLeadingSlash = ConfigurationLoader.loadResource("/needle.properties");
+        assertNotNull(loadResourceWithLeadingSlash);
+    }
 
-	@Test(expected = FileNotFoundException.class)
-	public void testLoadResource_NotFound() throws Exception {
-		ConfigurationLoader.loadResource("notfound.properties");
-	}
+    @Test(expected = FileNotFoundException.class)
+    public void testLoadResource_NotFound() throws Exception {
+        ConfigurationLoader.loadResource("notfound.properties");
+    }
 
 }

--- a/src/test/java/de/akquinet/jbosscc/needle/configuration/NeedleConfigurationResetRule.java
+++ b/src/test/java/de/akquinet/jbosscc/needle/configuration/NeedleConfigurationResetRule.java
@@ -1,0 +1,58 @@
+package de.akquinet.jbosscc.needle.configuration;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.lang.reflect.Field;
+
+import org.junit.rules.ExternalResource;
+
+/**
+ * Allows changing the NeedleConfiguration on a per test level. Usage:
+ * 
+ * <pre>
+ * 
+ * &#064;ClassRule
+ * public static NeedleConfigurationResetRule configurationReset = new NeedleConfigurationResetRule(&quot;myResource&quot;);
+ * </pre>
+ * 
+ * @author Jan Galinski, Holisticon AG
+ */
+public final class NeedleConfigurationResetRule extends ExternalResource {
+
+    private final String resourceName;
+
+    public NeedleConfigurationResetRule(final String resourceName) {
+        this.resourceName = resourceName;
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        super.before();
+        getAndResetInstance(resourceName);
+    }
+
+    @Override
+    protected void after() {
+        super.after();
+        getAndResetInstance();
+    }
+
+    public static NeedleConfiguration getAndResetInstance() {
+        return getAndResetInstance(ConfigurationLoader.CUSTOM_CONFIGURATION_FILENAME);
+    }
+
+    public static NeedleConfiguration getAndResetInstance(final String resourceName) {
+        try {
+            final Field instanceField = NeedleConfiguration.class.getDeclaredField("INSTANCE");
+            instanceField.setAccessible(true);
+            instanceField.set(NeedleConfiguration.class, null);
+            assertThat(instanceField.get(NeedleConfiguration.class), nullValue());
+
+            return NeedleConfiguration.init(resourceName);
+        }
+        catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/de/akquinet/jbosscc/needle/configuration/NeedleConfigurationTest.java
+++ b/src/test/java/de/akquinet/jbosscc/needle/configuration/NeedleConfigurationTest.java
@@ -2,8 +2,8 @@ package de.akquinet.jbosscc.needle.configuration;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import java.lang.annotation.Annotation;
 
+import java.lang.annotation.Annotation;
 import java.util.Set;
 
 import org.junit.Test;
@@ -15,19 +15,21 @@ import de.akquinet.jbosscc.needle.mock.EasyMockProvider;
 
 public class NeedleConfigurationTest {
 
+    private final NeedleConfiguration needleConfiguration = NeedleConfiguration.get();
+
     @Test
     public void testGetMockProviderClass_Default() throws Exception {
-        assertEquals(EasyMockProvider.class.getName(), NeedleConfiguration.getMockProviderClassName());
+        assertEquals(EasyMockProvider.class.getName(), needleConfiguration.getMockProviderClassName());
     }
 
     @Test
     public void testDBOperationClassName_NoDefaults() throws Exception {
-        assertEquals(HSQLDeleteOperation.class.getName(), NeedleConfiguration.getDBOperationClassName());
+        assertEquals(HSQLDeleteOperation.class.getName(), needleConfiguration.getDBOperationClassName());
     }
 
     @Test
     public void testGetCustomInjectionAnnotations() throws Exception {
-        Set<Class<Annotation>> customInjectionAnnotations = NeedleConfiguration.getCustomInjectionAnnotations();
+        final Set<Class<Annotation>> customInjectionAnnotations = needleConfiguration.getCustomInjectionAnnotations();
         assertEquals(2, customInjectionAnnotations.size());
         assertTrue(customInjectionAnnotations.contains(CustomInjectionAnnotation1.class));
         assertTrue(customInjectionAnnotations.contains(CustomInjectionAnnotation2.class));

--- a/src/test/java/de/akquinet/jbosscc/needle/configuration/NeedleConfigurationTest.java
+++ b/src/test/java/de/akquinet/jbosscc/needle/configuration/NeedleConfigurationTest.java
@@ -17,6 +17,12 @@ public class NeedleConfigurationTest {
 
     private final NeedleConfiguration needleConfiguration = NeedleConfiguration.get();
 
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowExceptionWhenConfigurationIsInitializedMoreThenOnce() throws Exception {
+        NeedleConfiguration.init();
+        NeedleConfiguration.init();
+    }
+
     @Test
     public void testGetMockProviderClass_Default() throws Exception {
         assertEquals(EasyMockProvider.class.getName(), needleConfiguration.getMockProviderClassName());

--- a/src/test/java/de/akquinet/jbosscc/needle/configuration/NeedleConfigurationWithDifferentResourceTest.java
+++ b/src/test/java/de/akquinet/jbosscc/needle/configuration/NeedleConfigurationWithDifferentResourceTest.java
@@ -1,0 +1,31 @@
+package de.akquinet.jbosscc.needle.configuration;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import de.akquinet.jbosscc.needle.db.operation.hsql.HSQLDeleteOperation;
+
+public class NeedleConfigurationWithDifferentResourceTest {
+
+    // load mockito resource and switch back to default after().
+    @ClassRule
+    public static NeedleConfigurationResetRule configurationReset = new NeedleConfigurationResetRule("needle-mockito");
+
+    private final NeedleConfiguration needleConfiguration = NeedleConfiguration.get();
+
+    @Test
+    public void shouldReTestWithDifferentPropertyFile() throws Exception {
+
+        // repeat other tests on needle-mockito file
+        assertThat(needleConfiguration.getMockProviderClassName(), is("de.akquinet.jbosscc.needle.mock.MockitoProvider"));
+        assertEquals(HSQLDeleteOperation.class.getName(), needleConfiguration.getDBOperationClassName());
+        assertEquals(HSQLDeleteOperation.class.getName(), needleConfiguration.getDBOperationClassName());
+        assertEquals(HSQLDeleteOperation.class.getName(), needleConfiguration.getDBOperationClassName());
+
+    }
+
+}

--- a/src/test/java/de/akquinet/jbosscc/needle/mock/MockitoProviderTest.java
+++ b/src/test/java/de/akquinet/jbosscc/needle/mock/MockitoProviderTest.java
@@ -1,39 +1,78 @@
 package de.akquinet.jbosscc.needle.mock;
 
-import java.util.Map;
-
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.Test;
 import org.mockito.Mockito;
 
 public class MockitoProviderTest {
 
-	private MockitoProvider mockitoProvider = new MockitoProvider();
+    private final MockitoProvider mockitoProvider = new MockitoProvider();
 
-	@Test
-	public void testCreateMockComponent() throws Exception {
-		@SuppressWarnings("unchecked")
-		Map<String, String> mapMock = mockitoProvider.createMockComponent(Map.class);
+    @Test
+    public void shouldCreateMockComponent() throws Exception {
+        @SuppressWarnings("unchecked")
+        final Map<String, String> mapMock = mockitoProvider.createMockComponent(Map.class);
 
-		String key = "key";
-		String value = "value";
+        final String key = "key";
+        final String value = "value";
 
-		Mockito.when(mapMock.get(key)).thenReturn(value);
+        Mockito.when(mapMock.get(key)).thenReturn(value);
 
-		assertEquals(value, mapMock.get(key));
+        assertEquals(value, mapMock.get(key));
 
-	}
+    }
 
-	@Test
-	public void testCreateMockComponent_Final() throws Exception {
-		assertNull(mockitoProvider.createMockComponent(String.class));
-	}
+    @Test
+    public void shouldCreateSpyComponent() throws Exception {
+        Map<String, String> mapSpy = new HashMap<String, String>();
+        mapSpy = mockitoProvider.createSpyComponent(mapSpy);
 
-	@Test
-	public void testCreateMockComponent_isPrimitive() throws Exception {
-		assertNull(mockitoProvider.createMockComponent(int.class));
-	}
+        mapSpy.put("foo", "a");
+
+        when(mapSpy.get("bar")).thenReturn("b");
+
+        assertThat(mapSpy.get("foo"), is("a"));
+        assertThat(mapSpy.get("bar"), is("b"));
+
+        verify(mapSpy).get("foo");
+        verify(mapSpy).get("bar");
+        verify(mapSpy).put("foo", "a");
+        verifyNoMoreInteractions(mapSpy);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToCreateSpyWhenInstanceIsNull() throws Exception {
+        mockitoProvider.createSpyComponent(null);
+    }
+
+    @Test
+    public void shouldSkipCreateMockComponentForFinalType() throws Exception {
+        assertNull(mockitoProvider.createMockComponent(String.class));
+    }
+
+    @Test
+    public void shouldSkipCreateMockComponentForPrimitiveType() throws Exception {
+        assertNull(mockitoProvider.createMockComponent(int.class));
+    }
+
+    @Test
+    public void shouldSkipCreateSpyComponentForFinal() throws Exception {
+        assertNull(mockitoProvider.createSpyComponent("foo"));
+    }
+
+    @Test
+    public void shouldSkipCreateSpyComponentForPrimitive() throws Exception {
+        assertNull(mockitoProvider.createSpyComponent(1));
+    }
 
 }

--- a/src/test/java/de/akquinet/jbosscc/needle/mock/SpyAnnotationProcessorTest.java
+++ b/src/test/java/de/akquinet/jbosscc/needle/mock/SpyAnnotationProcessorTest.java
@@ -1,0 +1,68 @@
+package de.akquinet.jbosscc.needle.mock;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.inject.Inject;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Spy;
+
+import de.akquinet.jbosscc.needle.annotation.InjectInto;
+import de.akquinet.jbosscc.needle.annotation.ObjectUnderTest;
+import de.akquinet.jbosscc.needle.configuration.NeedleConfigurationResetRule;
+import de.akquinet.jbosscc.needle.junit.NeedleRule;
+
+public class SpyAnnotationProcessorTest {
+
+    @ClassRule
+    public static NeedleConfigurationResetRule configurationReset = new NeedleConfigurationResetRule("needle-mockito");
+
+    public static interface B {
+
+        String getName();
+    }
+
+    public static class BImpl implements B {
+
+        @Override
+        public String getName() {
+            return "foo";
+        }
+    }
+
+    public static class A {
+
+        @Inject
+        private B b;
+
+        public String hello() {
+            return "hello " + b.getName();
+        }
+    }
+
+    @Rule
+    public final NeedleRule needle = new NeedleRule();
+
+    @ObjectUnderTest
+    @Spy
+    private A a;
+
+    @ObjectUnderTest(implementation = BImpl.class)
+    @InjectInto(targetComponentId = "a")
+    @Spy
+    private B b;
+
+    @Test
+    public void shouldInjectSpyForA() {
+        when(b.getName()).thenReturn("world");
+
+        assertThat(a.hello(), is("hello world"));
+        verify(a).hello();
+        verify(b).getName();
+    }
+}

--- a/src/test/java/de/akquinet/jbosscc/needle/mock/SpyAnnotationProcessorWithExistingObjectTest.java
+++ b/src/test/java/de/akquinet/jbosscc/needle/mock/SpyAnnotationProcessorWithExistingObjectTest.java
@@ -1,0 +1,52 @@
+package de.akquinet.jbosscc.needle.mock;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Spy;
+
+import de.akquinet.jbosscc.needle.annotation.InjectInto;
+import de.akquinet.jbosscc.needle.annotation.ObjectUnderTest;
+import de.akquinet.jbosscc.needle.configuration.NeedleConfigurationResetRule;
+import de.akquinet.jbosscc.needle.junit.NeedleRule;
+import de.akquinet.jbosscc.needle.mock.SpyAnnotationProcessorTest.A;
+import de.akquinet.jbosscc.needle.mock.SpyAnnotationProcessorTest.B;
+
+public class SpyAnnotationProcessorWithExistingObjectTest {
+
+    @ClassRule
+    public static NeedleConfigurationResetRule configurationReset = new NeedleConfigurationResetRule("needle-mockito");
+
+    @Rule
+    public final NeedleRule needle = new NeedleRule();
+
+    @ObjectUnderTest
+    @Spy
+    private A a;
+
+    // b becomes a spy, although it is already instantiated
+    @ObjectUnderTest
+    @InjectInto(targetComponentId = "a")
+    @Spy
+    private B b = new B() {
+
+        @Override
+        public String getName() {
+            return "world";
+        }
+    };
+
+    @Test
+    public void shouldInjectSpyForA() {
+        when(b.getName()).thenReturn("world");
+
+        assertThat(a.hello(), is("hello world"));
+        verify(a).hello();
+        verify(b).getName();
+    }
+}

--- a/src/test/java/de/akquinet/jbosscc/needle/postconstruct/PostConstructProcessorTest.java
+++ b/src/test/java/de/akquinet/jbosscc/needle/postconstruct/PostConstructProcessorTest.java
@@ -39,7 +39,7 @@ public class PostConstructProcessorTest {
     }
 
     /**
-     * a dummy class with init()
+     * used to test postconstruct hierarchy
      */
     public class C extends B {
 

--- a/src/test/java/de/akquinet/jbosscc/needle/postconstruct/PostConstructProcessorTest.java
+++ b/src/test/java/de/akquinet/jbosscc/needle/postconstruct/PostConstructProcessorTest.java
@@ -1,8 +1,12 @@
 package de.akquinet.jbosscc.needle.postconstruct;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
+import java.lang.reflect.Method;
 import java.util.HashSet;
+import java.util.Set;
 
 import javax.annotation.PostConstruct;
 
@@ -32,7 +36,7 @@ public class PostConstructProcessorTest {
     public class B extends A {
 
         @PostConstruct
-        public void init() {
+        protected void init() {
             runnableMock.run();
         }
 
@@ -51,7 +55,6 @@ public class PostConstructProcessorTest {
     }
 
     private static final HashSet<Class<?>> ANNOTATIONS = new HashSet<Class<?>>();
-
     static {
         ANNOTATIONS.add(PostConstruct.class);
     }
@@ -116,6 +119,12 @@ public class PostConstructProcessorTest {
         postConstructProcessor.process(getObjectUnderTestAnnotation("instanceAndParentClassHavePostconstructMethods"),
                 instanceAndParentClassHavePostconstructMethods);
         EasyMock.verify(runnableMock, secondRunnableMock);
+    }
+
+    @Test
+    public void shouldFindTwoPostconstructMethodsForC() throws Exception {
+        final Set<Method> methods = postConstructProcessor.getPostConstructMethods(C.class);
+        assertThat(methods.size(), is(2));
     }
 
     private ObjectUnderTest getObjectUnderTestAnnotation(final String fieldname) {

--- a/src/test/java/de/akquinet/jbosscc/needle/reflection/DerivedClass.java
+++ b/src/test/java/de/akquinet/jbosscc/needle/reflection/DerivedClass.java
@@ -2,35 +2,38 @@ package de.akquinet.jbosscc.needle.reflection;
 
 import java.util.Collection;
 
+@SuppressWarnings("unused")
 public class DerivedClass extends SampleClass {
 
-	private String field;
+    private String field;
 
-	private Boolean booleanField;
+    private Boolean booleanField;
 
-	private Collection<?> collectionField2;
+    private Collection<?> collectionField2;
 
-	public Boolean getBooleanField() {
-		return booleanField;
-	}
+    public Boolean getBooleanField() {
+        return booleanField;
+    }
 
-	@Override
-	public void toOverride() {
-		super.toOverride();
-	}
+    @Override
+    public void toOverride() {
+        super.toOverride();
+    }
 
-	@SuppressWarnings("unused")
-	private boolean testInvokeWithPrimitive(final int intValue, final float floatValue, final char charValue,
-	        final boolean booleanValue, final long longValue, final byte byteValue, final short shortValue,
-	        final double doubleValue) {
-		return true;
-	}
+    private boolean testInvokeWithPrimitive(final int intValue, final float floatValue, final char charValue,
+            final boolean booleanValue, final long longValue, final byte byteValue, final short shortValue,
+            final double doubleValue) {
+        return true;
+    }
 
-	@SuppressWarnings("unused")
-	private boolean testInvokeWithObjects(final Integer intValue, final Float floatValue, final Character charValue,
-	        final Boolean booleanValue, final Long longValue, final Byte byteValue, final Short shortValue,
-	        final Double doubleValue) {
-		return true;
-	}
+    private boolean testInvokeWithObjects(final Integer intValue, final Float floatValue, final Character charValue,
+            final Boolean booleanValue, final Long longValue, final Byte byteValue, final Short shortValue,
+            final Double doubleValue) {
+        return true;
+    }
 
+    @MyAnnotation
+    private void aPrivateMethod() {
+        // empty
+    }
 }

--- a/src/test/java/de/akquinet/jbosscc/needle/reflection/ReflectionUtilTest.java
+++ b/src/test/java/de/akquinet/jbosscc/needle/reflection/ReflectionUtilTest.java
@@ -1,6 +1,7 @@
 package de.akquinet.jbosscc.needle.reflection;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -24,203 +25,209 @@ import de.akquinet.jbosscc.needle.mock.MockitoProvider;
 
 public class ReflectionUtilTest {
 
-	@Test
-	public void testCanLookupPrivateFieldFromSuperclass() {
-		DerivedClass sample = new DerivedClass();
+    @Test
+    public void testCanLookupPrivateFieldFromSuperclass() {
+        final DerivedClass sample = new DerivedClass();
 
-		List<Field> result = ReflectionUtil.getAllFieldsWithAnnotation(sample, MyAnnotation.class);
+        final List<Field> result = ReflectionUtil.getAllFieldsWithAnnotation(sample, MyAnnotation.class);
 
-		assertThat(result.size(), equalTo(1));
-	}
+        assertThat(result.size(), equalTo(1));
+    }
 
-	@Test
-	public void testCanInjectIntoPrivateFieldFromSuperclass() {
-		DerivedClass sample = new DerivedClass();
+    @Test
+    public void testCanInjectIntoPrivateFieldFromSuperclass() {
+        final DerivedClass sample = new DerivedClass();
 
-		ReflectionUtil.setFieldValue(sample, "aPrivateField", "aValue");
+        ReflectionUtil.setFieldValue(sample, "aPrivateField", "aValue");
 
-		assertThat(sample.getPrivateField(), equalTo("aValue"));
-	}
+        assertThat(sample.getPrivateField(), equalTo("aValue"));
+    }
 
-	@Test
-	public void testGetAllFields() throws Exception {
-		List<Field> allFields = ReflectionUtil.getAllFields(DerivedClass.class);
+    @Test
+    public void testGetAllFields() throws Exception {
+        final List<Field> allFields = ReflectionUtil.getAllFields(DerivedClass.class);
 
-		assertThat(allFields.size(), equalTo(5));
-	}
+        assertThat(allFields.size(), equalTo(5));
+    }
 
-	@Test
-	public void testAllAnnotatedFields() throws Exception {
-	    final Map<Class<? extends Annotation>, List<Field>> allAnnotatedFields = ReflectionUtil.getAllAnnotatedFields(MyComponentBean.class);
-	    assertEquals(4, allAnnotatedFields.size());
+    @Test
+    public void testAllAnnotatedFields() throws Exception {
+        final Map<Class<? extends Annotation>, List<Field>> allAnnotatedFields = ReflectionUtil.getAllAnnotatedFields(MyComponentBean.class);
+        assertEquals(4, allAnnotatedFields.size());
 
-	    List<Field> list = allAnnotatedFields.get(Resource.class);
-	    assertEquals(3,list.size());
+        final List<Field> list = allAnnotatedFields.get(Resource.class);
+        assertEquals(3, list.size());
 
     }
 
-	@Test
-	public void testInvokeMethod() throws Exception {
-		String invokeMethod = (String) ReflectionUtil.invokeMethod(this, "test");
-		assertEquals("Hello World", invokeMethod);
-	}
+    @Test
+    public void testInvokeMethod() throws Exception {
+        final String invokeMethod = (String)ReflectionUtil.invokeMethod(this, "test");
+        assertEquals("Hello World", invokeMethod);
+    }
 
-	@Test
-	public void testGetFieldValue() throws Exception {
-		Address address = new Address();
-		address.setId(1L);
+    @Test
+    public void testGetFieldValue() throws Exception {
+        final Address address = new Address();
+        address.setId(1L);
 
-		assertEquals(1L, ReflectionUtil.getFieldValue(address, Address.class, "id"));
-	}
+        assertEquals(1L, ReflectionUtil.getFieldValue(address, Address.class, "id"));
+    }
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testGetFieldValue_Exception() throws Exception {
-		Address address = new Address();
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetFieldValue_Exception() throws Exception {
+        final Address address = new Address();
 
-		assertEquals(1L, ReflectionUtil.getFieldValue(address, Address.class, "notexisting"));
-	}
+        assertEquals(1L, ReflectionUtil.getFieldValue(address, Address.class, "notexisting"));
+    }
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testGetFieldValue_ByField_Exception() throws Exception {
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetFieldValue_ByField_Exception() throws Exception {
 
-		assertEquals(1L, ReflectionUtil.getFieldValue(null, ReflectionUtil.getField(Address.class, "id")));
-	}
+        assertEquals(1L, ReflectionUtil.getFieldValue(null, ReflectionUtil.getField(Address.class, "id")));
+    }
 
-	@Test
-	public void testGetField_NoSuchField() throws Exception {
-		assertNull(ReflectionUtil.getField(String.class, "fieldName"));
-	}
+    @Test
+    public void testGetField_NoSuchField() throws Exception {
+        assertNull(ReflectionUtil.getField(String.class, "fieldName"));
+    }
 
-	@Test
-	public void testGetField_DerivedClass() throws Exception {
-		assertNotNull(ReflectionUtil.getField(DerivedClass.class, "aPrivateField"));
-	}
+    @Test
+    public void testGetField_DerivedClass() throws Exception {
+        assertNotNull(ReflectionUtil.getField(DerivedClass.class, "aPrivateField"));
+    }
 
-	@Test
-	public void testGetMethodAndInvoke() throws Exception {
-		Method method = ReflectionUtil.getMethod(DerivedClass.class, "testGetMethod", String.class, int.class,
-		        Object.class);
-		assertNotNull(method);
+    @Test
+    public void testGetMethodAndInvoke() throws Exception {
+        final Method method = ReflectionUtil.getMethod(DerivedClass.class, "testGetMethod", String.class, int.class,
+                Object.class);
+        assertNotNull(method);
 
-		Object result = ReflectionUtil.invokeMethod(method, new DerivedClass(), "Hello", 1, "");
-		assertEquals("Hello", result.toString());
+        final Object result = ReflectionUtil.invokeMethod(method, new DerivedClass(), "Hello", 1, "");
+        assertEquals("Hello", result.toString());
 
-	}
+    }
 
-	@Test
-	public void testGetMethod() throws Exception {
-		List<Method> methods = ReflectionUtil.getMethods(DerivedClass.class);
+    @Test
+    public void testGetMethod() throws Exception {
+        final List<Method> methods = ReflectionUtil.getMethods(DerivedClass.class);
 
-		assertEquals(13, methods.size());
+        assertEquals(13, methods.size());
 
-	}
+    }
 
-	@Test(expected = UnsupportedOperationException.class)
-	public void testInvokeMethod_Exception() throws Exception {
-		ReflectionUtil.invokeMethod(this, "testException");
-	}
+    @Test(expected = UnsupportedOperationException.class)
+    public void testInvokeMethod_Exception() throws Exception {
+        ReflectionUtil.invokeMethod(this, "testException");
+    }
 
-	@Test
-	public void testGetAllFieldsAssinableFrom() throws Exception {
-		List<Field> allFieldsAssinableFromBoolean = ReflectionUtil.getAllFieldsAssinableFrom(Boolean.class,
-		        DerivedClass.class);
-		assertEquals(1, allFieldsAssinableFromBoolean.size());
+    @Test
+    public void testGetAllFieldsAssinableFrom() throws Exception {
+        final List<Field> allFieldsAssinableFromBoolean = ReflectionUtil.getAllFieldsAssinableFrom(Boolean.class,
+                DerivedClass.class);
+        assertEquals(1, allFieldsAssinableFromBoolean.size());
 
-		List<Field> allFieldsAssinableFromList = ReflectionUtil.getAllFieldsAssinableFrom(List.class,
-		        DerivedClass.class);
-		assertEquals(2, allFieldsAssinableFromList.size());
+        final List<Field> allFieldsAssinableFromList = ReflectionUtil.getAllFieldsAssinableFrom(List.class,
+                DerivedClass.class);
+        assertEquals(2, allFieldsAssinableFromList.size());
 
-		List<Field> allFieldsAssinableFromCollection = ReflectionUtil.getAllFieldsAssinableFrom(Collection.class,
-		        DerivedClass.class);
-		assertEquals(2, allFieldsAssinableFromCollection.size());
+        final List<Field> allFieldsAssinableFromCollection = ReflectionUtil.getAllFieldsAssinableFrom(Collection.class,
+                DerivedClass.class);
+        assertEquals(2, allFieldsAssinableFromCollection.size());
 
-		List<Field> allFieldsAssinableFromString = ReflectionUtil.getAllFieldsAssinableFrom(String.class,
-		        DerivedClass.class);
-		assertEquals(2, allFieldsAssinableFromString.size());
-	}
+        final List<Field> allFieldsAssinableFromString = ReflectionUtil.getAllFieldsAssinableFrom(String.class,
+                DerivedClass.class);
+        assertEquals(2, allFieldsAssinableFromString.size());
+    }
 
-	@Test
-	public void testCreateInstance() throws Exception {
-		assertNotNull(ReflectionUtil.createInstance(MockitoProvider.class));
+    @Test
+    public void testCreateInstance() throws Exception {
+        assertNotNull(ReflectionUtil.createInstance(MockitoProvider.class));
 
-		assertEquals("Hello", ReflectionUtil.createInstance(String.class, "Hello"));
-	}
+        assertEquals("Hello", ReflectionUtil.createInstance(String.class, "Hello"));
+    }
 
-	@Test(expected = Exception.class)
-	public void testCreateInstance_Exception() throws Exception {
-		ReflectionUtil.createInstance(InjectionTargetInformation.class);
-	}
+    @Test(expected = Exception.class)
+    public void testCreateInstance_Exception() throws Exception {
+        ReflectionUtil.createInstance(InjectionTargetInformation.class);
+    }
 
-	@Test
-	public void testInvokeMethod_checkArgumentsWithPrimitives() throws Exception {
-		DerivedClass derivedClass = new DerivedClass();
+    @Test
+    public void testInvokeMethod_checkArgumentsWithPrimitives() throws Exception {
+        final DerivedClass derivedClass = new DerivedClass();
 
-		final int intValue = 1;
-		final float floatValue = 0F;
-		final char charValue = 'c';
-		final boolean booleanValue = true;
-		final long longValue = 10L;
-		final byte byteValue = 2;
-		final short shortValue = 32;
-		final double doubleValue = 24.1;
+        final int intValue = 1;
+        final float floatValue = 0F;
+        final char charValue = 'c';
+        final boolean booleanValue = true;
+        final long longValue = 10L;
+        final byte byteValue = 2;
+        final short shortValue = 32;
+        final double doubleValue = 24.1;
 
-		Object resultPrimatives = ReflectionUtil.invokeMethod(derivedClass, "testInvokeWithPrimitive", intValue,
-		        floatValue, charValue, booleanValue, longValue, byteValue, shortValue, doubleValue);
-		assertEquals(true, resultPrimatives);
+        final Object resultPrimatives = ReflectionUtil.invokeMethod(derivedClass, "testInvokeWithPrimitive", intValue,
+                floatValue, charValue, booleanValue, longValue, byteValue, shortValue, doubleValue);
+        assertEquals(true, resultPrimatives);
 
-		Object resultObjects = ReflectionUtil.invokeMethod(derivedClass, "testInvokeWithObjects", intValue, floatValue,
-		        charValue, booleanValue, longValue, byteValue, shortValue, doubleValue);
-		assertEquals(true, resultObjects);
-	}
+        final Object resultObjects = ReflectionUtil.invokeMethod(derivedClass, "testInvokeWithObjects", intValue, floatValue,
+                charValue, booleanValue, longValue, byteValue, shortValue, doubleValue);
+        assertEquals(true, resultObjects);
+    }
 
-	@Test
-	public void testInvokeMethod_checkArgumentsWithObjects() throws Exception {
-		DerivedClass derivedClass = new DerivedClass();
+    @Test
+    public void testInvokeMethod_checkArgumentsWithObjects() throws Exception {
+        final DerivedClass derivedClass = new DerivedClass();
 
-		final Integer intValue = 1;
-		final Float floatValue = 0F;
-		final Character charValue = 'c';
-		final Boolean booleanValue = true;
-		final Long longValue = 10L;
-		final Byte byteValue = 2;
-		final Short shortValue = 32;
-		final Double doubleValue = 24.1;
+        final Integer intValue = 1;
+        final Float floatValue = 0F;
+        final Character charValue = 'c';
+        final Boolean booleanValue = true;
+        final Long longValue = 10L;
+        final Byte byteValue = 2;
+        final Short shortValue = 32;
+        final Double doubleValue = 24.1;
 
-		Object resultPrimatives = ReflectionUtil.invokeMethod(derivedClass, "testInvokeWithPrimitive", intValue,
-		        floatValue, charValue, booleanValue, longValue, byteValue, shortValue, doubleValue);
-		assertEquals(true, resultPrimatives);
+        final Object resultPrimatives = ReflectionUtil.invokeMethod(derivedClass, "testInvokeWithPrimitive", intValue,
+                floatValue, charValue, booleanValue, longValue, byteValue, shortValue, doubleValue);
+        assertEquals(true, resultPrimatives);
 
-		Object resultObjects = ReflectionUtil.invokeMethod(derivedClass, "testInvokeWithObjects", intValue, floatValue,
-		        charValue, booleanValue, longValue, byteValue, shortValue, doubleValue);
-		assertEquals(true, resultObjects);
-	}
+        final Object resultObjects = ReflectionUtil.invokeMethod(derivedClass, "testInvokeWithObjects", intValue, floatValue,
+                charValue, booleanValue, longValue, byteValue, shortValue, doubleValue);
+        assertEquals(true, resultObjects);
+    }
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testInvokeMethod_NoSuchMethod() throws Exception {
-		DerivedClass derivedClass = new DerivedClass();
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvokeMethod_NoSuchMethod() throws Exception {
+        final DerivedClass derivedClass = new DerivedClass();
 
-		ReflectionUtil.invokeMethod(derivedClass, "testInvokeWithPrimitive");
+        ReflectionUtil.invokeMethod(derivedClass, "testInvokeWithPrimitive");
 
-	}
+    }
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testInvokeMethod_WithWrongParameter() throws Exception {
-		ReflectionUtil.invokeMethod(this, "test", new Double(1.));
-	}
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvokeMethod_WithWrongParameter() throws Exception {
+        ReflectionUtil.invokeMethod(this, "test", new Double(1.));
+    }
 
-	@SuppressWarnings("unused")
-	private String test() {
-		return "Hello World";
-	}
+    @Test
+    public void shouldFindAllMethodsWithMyAnnotation() throws Exception {
+        final List<Method> result = ReflectionUtil.getAllMethodsWithAnnotation(DerivedClass.class, MyAnnotation.class);
+        assertThat(result.size(), is(2));
+    }
 
-	@SuppressWarnings("unused")
-	private String test(int value) {
-		return "";
-	}
+    @SuppressWarnings("unused")
+    private String test() {
+        return "Hello World";
+    }
 
-	@SuppressWarnings("unused")
-	private void testException() throws UnsupportedOperationException {
-		throw new UnsupportedOperationException();
-	}
+    @SuppressWarnings("unused")
+    private String test(final int value) {
+        return "";
+    }
+
+    @SuppressWarnings("unused")
+    private void testException() throws UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
 
 }

--- a/src/test/java/de/akquinet/jbosscc/needle/reflection/SampleClass.java
+++ b/src/test/java/de/akquinet/jbosscc/needle/reflection/SampleClass.java
@@ -4,26 +4,31 @@ import java.util.Collection;
 
 public class SampleClass {
 
-	@MyAnnotation
-	private String aPrivateField;
+    @MyAnnotation
+    private String aPrivateField;
 
-	@SuppressWarnings("unused")
-	private Collection<?> collectionField2;
+    @SuppressWarnings("unused")
+    private Collection<?> collectionField2;
 
-	public String getPrivateField() {
-		return aPrivateField;
-	}
+    public String getPrivateField() {
+        return aPrivateField;
+    }
 
-	@SuppressWarnings("unused")
-	private String testGetMethod(final String string, final int value, final Object obejct) {
-		return string;
-	}
+    @SuppressWarnings("unused")
+    private String testGetMethod(final String string, final int value, final Object obejct) {
+        return string;
+    }
 
-	public String testGetPulblicDerivedMethod(final String string, final int value, final Object obejct) {
-		return string;
-	}
+    public String testGetPulblicDerivedMethod(final String string, final int value, final Object obejct) {
+        return string;
+    }
 
+    public void toOverride() {
+    }
 
-	public void toOverride(){}
+    @MyAnnotation
+    protected void aProtectedMethod() {
+        // empty
+    }
 
 }

--- a/src/test/resources/needle-mockito.properties
+++ b/src/test/resources/needle-mockito.properties
@@ -1,0 +1,9 @@
+mock.provider						= de.akquinet.jbosscc.needle.mock.MockitoProvider
+custom.injection.annotations		= de.akquinet.jbosscc.needle.injection.CustomInjectionAnnotation1,de.akquinet.jbosscc.needle.injection.CustomInjectionAnnotation2,de.unknown.Annotation
+custom.injection.provider.classes	= de.akquinet.jbosscc.needle.injection.CustomMapInjectionProvider,de.unknown.InjectionProvider
+db.operation						= de.akquinet.jbosscc.needle.db.operation.hsql.HSQLDeleteOperation
+
+jdbc.driver		= org.hsqldb.jdbcDriver
+jdbc.url		= jdbc:hsqldb:mem:memoryDB
+jdbc.user		= sa
+jdbc.password	=


### PR DESCRIPTION
issue #15: I realized that switching between Easymock and Mockito is only needed within needle-testing, so instead of rewriting the configuration-core, I just ensured that no static fields are instantiated with conf-values (no way to change them then). Now all configuration is loaded "on demand" and we can use the NeedleConfigurationResetRule to wrap tests that should not use te default properties.

also addressed with this request: #12: when using mockito, it is now possible to use objects under test as spy() with a simple annotation:

@ObjectUnderTest
@Spy
private MyBean myBeanSpy;
