### PR TITLE
Fix #27 (ReflectionUtil too chatty)

### DIFF
--- a/src/main/java/de/akquinet/jbosscc/needle/reflection/DerivedClassIterator.java
+++ b/src/main/java/de/akquinet/jbosscc/needle/reflection/DerivedClassIterator.java
@@ -9,16 +9,18 @@ abstract class DerivedClassIterator {
         this.clazz = clazz;
     }
 
-    void iterate() {
+    boolean iterate() {
         Class<?> superClazz = clazz;
 
+        boolean success = false;
         while (superClazz != null) {
 
-            handleClass(superClazz);
+            success |= handleClass(superClazz);
 
             superClazz = superClazz.getSuperclass();
         }
+        return success;
     }
 
-    protected abstract void handleClass(Class<?> clazz);
+    protected abstract boolean handleClass(Class<?> clazz);
 }

--- a/src/main/java/de/akquinet/jbosscc/needle/reflection/ReflectionUtil.java
+++ b/src/main/java/de/akquinet/jbosscc/needle/reflection/ReflectionUtil.java
@@ -45,7 +45,7 @@ public final class ReflectionUtil {
         new DerivedClassIterator(clazz) {
 
             @Override
-            protected void handleClass(final Class<?> clazz) {
+            protected boolean handleClass(final Class<?> clazz) {
                 final Field[] fields = clazz.getDeclaredFields();
 
                 for (final Field field : fields) {
@@ -53,6 +53,7 @@ public final class ReflectionUtil {
                         result.add(field);
                     }
                 }
+                return true;
 
             }
         }.iterate();
@@ -67,13 +68,14 @@ public final class ReflectionUtil {
         new DerivedClassIterator(clazz) {
 
             @Override
-            protected void handleClass(final Class<?> clazz) {
+            protected boolean handleClass(final Class<?> clazz) {
 
                 for (final Method method : clazz.getDeclaredMethods()) {
                     if (method.isAnnotationPresent(annotation)) {
                         result.add(method);
                     }
                 }
+                return true;
 
             }
         }.iterate();
@@ -110,7 +112,7 @@ public final class ReflectionUtil {
         new DerivedClassIterator(clazz) {
 
             @Override
-            protected void handleClass(final Class<?> clazz) {
+            protected boolean handleClass(final Class<?> clazz) {
                 final Field[] fields = clazz.getDeclaredFields();
 
                 for (final Field field : fields) {
@@ -118,6 +120,7 @@ public final class ReflectionUtil {
                         result.add(field);
                     }
                 }
+                return true;
 
             }
         }.iterate();
@@ -139,10 +142,11 @@ public final class ReflectionUtil {
         new DerivedClassIterator(clazz) {
 
             @Override
-            protected void handleClass(final Class<?> clazz) {
+            protected boolean handleClass(final Class<?> clazz) {
                 final Field[] fields = clazz.getDeclaredFields();
 
                 Collections.addAll(result, fields);
+                return true;
 
             }
         }.iterate();
@@ -195,21 +199,24 @@ public final class ReflectionUtil {
      */
     public static void setFieldValue(final Object object, final String fieldName, final Object value) {
 
-        new DerivedClassIterator(object.getClass()) {
+        final boolean success = new DerivedClassIterator(object.getClass()) {
 
             @Override
-            protected void handleClass(final Class<?> clazz) {
+            protected boolean handleClass(final Class<?> clazz) {
                 try {
                     setFieldValue(object, clazz, fieldName, value);
-                    return;
+                    return true;
                 }
                 catch (final NoSuchFieldException e) {
-                    LOG.warn("could not set field " + fieldName + " value " + value, e);
+                    LOG.debug("could not set field " + fieldName + " value " + value, e);
                 }
-
+                return false;
             }
         }.iterate();
 
+        if (!success) {
+            LOG.warn("could not set field " + fieldName + " value " + value);
+        }
     }
 
     /**
@@ -336,14 +343,15 @@ public final class ReflectionUtil {
         new DerivedClassIterator(clazz) {
 
             @Override
-            protected void handleClass(final Class<?> clazz) {
+            protected boolean handleClass(final Class<?> clazz) {
                 try {
                     result.add(clazz.getDeclaredMethod(methodName, parameterTypes));
-                    return;
+                    return true;
                 }
                 catch (final Exception e) {
                     // do nothing
                 }
+                return false;
 
             }
         }.iterate();


### PR DESCRIPTION
The reflection util was spitting out warning messages even when it
successfully updated a field value. There was no way to get feedback
from the DerivedClassIterator whether it successfully handled a clazz or
not. I've added a feedback mechanism to the DervicedClassIterator,
updated all implementations and made the setFieldValue only generate a
warn-level msg when it really failed.
